### PR TITLE
Tweak ESLint config and docs

### DIFF
--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
 
     // require or disallow use of semicolons instead of ASI (fixable)
     semi: [ 'error', 'always' ],
-
+    
     'bad-text': 'error',
 
     // Custom rule for checking the copyright.
@@ -359,41 +359,41 @@ module.exports = {
     event: 'off',
 
     // read-only globals ---------------------------------
-    phet: false,
+    phet: 'readonly',
 
     // allow assertions
-    assert: false,
+    assert: 'readonly',
 
     // allow slow assertions
-    assertSlow: false,
+    assertSlow: 'readonly',
 
-    phetio: false,
+    phetio: 'readonly',
 
     // underscore, lodash
-    _: false,
+    _: 'readonly',
 
     // jQuery
-    $: false,
+    $: 'readonly',
 
-    document: false,
+    document: 'readonly',
 
     // for linting Node.js code
-    global: false,
+    global: 'readonly',
 
     // QUnit
-    QUnit: false,
+    QUnit: 'readonly',
 
     // as used in Gruntfile.js
-    module: false,
+    module: 'readonly',
 
     // Misc
-    QueryStringMachine: false,
+    QueryStringMachine: 'readonly',
 
     // sole/tween.js
-    TWEEN: false,
+    TWEEN: 'readonly',
 
-    window: false,
+    window: 'readonly',
 
-    handlePlaybackEvent: false
+    handlePlaybackEvent: 'readonly'
   }
 };

--- a/eslint/.eslintrc.js
+++ b/eslint/.eslintrc.js
@@ -3,11 +3,7 @@
 'use strict';
 
 /**
- * The base eslint configuration for the project
- * values for rules:
- * 0 - no error
- * 1 - warn
- * 2 - error
+ * The base eslint configuration for the PhET projects.
  *
  * @author Sam Reid (PhET Interactive Simulations)
  * @author Michael Kauzmann (PhET Interactive Simulations)
@@ -30,52 +26,47 @@ module.exports = {
     'no-useless-catch': 'off',
 
     // specify whether backticks, double or single quotes should be used (fixable)
-    quotes: [
-      2,
-      'single'
-    ],
+    quotes: [ 'error', 'single' ],
 
     // No dangling commas, see https://github.com/phetsims/tasks/issues/940
-    'comma-dangle': 2,
+    'comma-dangle': 'error',
 
     // require or disallow use of semicolons instead of ASI (fixable)
-    semi: [
-      2,
-      'always'
-    ],
-    'bad-text': 2,
+    semi: [ 'error', 'always' ],
+
+    'bad-text': 'error',
 
     // Custom rule for checking the copyright.
-    copyright: 2,
+    copyright: 'error',
 
     // Custom rule for checking TODOs have issues
-    'todo-should-have-issue': 2,
+    'todo-should-have-issue': 'error',
 
     // Custom rule for ensuring that images and text use scenery node
-    'no-html-constructors': 2,
+    'no-html-constructors': 'error',
 
     // enforce one true brace style
     'brace-style': [ 'error', 'stroustrup', { allowSingleLine: true } ],
 
     // Custom rule for avoiding instanceof Array.
-    'no-instanceof-array': 2,
+    'no-instanceof-array': 'error',
 
     // Custom rule for keeping import statements on a single line.
-    'single-line-import': 2,
+    'single-line-import': 'error',
 
     // method declarations must have a visibility annotation
-    'visibility-annotation': 2,
+    'visibility-annotation': 'error',
 
     // Enumerations should be named like classes/types
-    'enumeration-casing': 2,
+    'enumeration-casing': 'error',
 
     // key and value arguments to namespace.register() must match
-    'namespace-match': 2,
+    'namespace-match': 'error',
 
     // disallow declaration of variables that are not used in the code (recommended)
     // Overridden to allow unused args
     'no-unused-vars': [
-      2,
+      'error',
       {
         vars: 'all',
         args: 'none'
@@ -84,7 +75,7 @@ module.exports = {
 
     // error when let is used but the variable is never reassigned, see https://github.com/phetsims/tasks/issues/973
     'prefer-const': [
-      2,
+      'error',
       {
         destructuring: 'any',
         ignoreReadBeforeAssign: false
@@ -92,78 +83,72 @@ module.exports = {
     ],
 
     // require the use of === and !== (fixable)
-    eqeqeq: 2,
+    eqeqeq: 'error',
 
     // specify curly brace conventions for all control statements
-    curly: 2,
+    curly: 'error',
 
     // disallow use of arguments.caller or arguments.callee
-    'no-caller': 2,
+    'no-caller': 'error',
 
     // disallow use of the new operator when not part of an assignment or comparison
-    'no-new': 2,
+    'no-new': 'error',
 
     // controls location of Use Strict Directives
     // strict: 2, // TODO: restore this, see https://github.com/phetsims/chipper/issues/820
 
     // Avoid code that looks like two expressions but is actually one
-    'no-unexpected-multiline': 2,
+    'no-unexpected-multiline': 'error',
 
     // encourages use of dot notation whenever possible
-    'dot-notation': 2,
+    'dot-notation': 'error',
 
     // disallow use of bitwise operators https://eslint.org/docs/rules/no-bitwise
     'no-bitwise': 'error',
 
     // disallow adding to native types
-    'no-extend-native': 2,
+    'no-extend-native': 'error',
 
     // disallow use of assignment in return statement
-    'no-return-assign': 2,
+    'no-return-assign': 'error',
 
     // disallow comparisons where both sides are exactly the same
-    'no-self-compare': 2,
+    'no-self-compare': 'error',
 
     // disallow unnecessary .call() and .apply()
-    'no-useless-call': 2,
+    'no-useless-call': 'error',
 
     // disallow use of undefined when initializing variables
-    'no-undef-init': 2,
+    'no-undef-init': 'error',
 
     // phet-specific require statement rules
-    'require-statement-match': 2,
-    'phet-io-require-contains-ifphetio': 2,
+    'require-statement-match': 'error',
+    'phet-io-require-contains-ifphetio': 'error',
 
     // Require @public/@private for this.something = result;
-    'property-visibility-annotation': 0,
-    'no-property-in-require-statement': 2,
+    'property-visibility-annotation': 'off',
+    'no-property-in-require-statement': 'error',
 
     // disallow assignment within variable declaration, see https://github.com/phetsims/chipper/issues/794
-    'no-multi-assign-on-declaration': 2,
+    'no-multi-assign-on-declaration': 'error',
 
     // get rid of extra spaces within lines of code
     'no-multi-spaces': [ 'error', { ignoreEOLComments: true } ],
 
     // permit only one var declaration per line, see #390
-    'one-var': [
-      2,
-      'never'
-    ],
+    'one-var': [ 'error', 'never' ],
 
     // require radix argument for parseInt
-    radix: 2,
+    radix: 'error',
 
     // require default case for switch statements
-    'default-case': 2,
+    'default-case': 'error',
 
     // do not allow fall-through cases in switch statements
-    'no-fallthrough': 2,
+    'no-fallthrough': 'error',
 
     // consistently use 'self' as the alias for 'this'
-    'consistent-this': [
-      2,
-      'self'
-    ],
+    'consistent-this': [ 'error', 'self' ],
 
     // require a capital letter for constructors
     'new-cap': [ 'error', {
@@ -178,15 +163,15 @@ module.exports = {
     'no-multiple-empty-lines': [ 'error', { max: 2, maxBOF: 0, maxEOF: 1 } ],
 
     // don't escape characters that don't need to be escaped
-    'no-useless-escape': 2,
+    'no-useless-escape': 'error',
 
     // never allow object shorthand for properties, functions are ok.
-    'phet-object-shorthand': 2,
+    'phet-object-shorthand': 'error',
 
     // disallow parens surrounding single args in arrow functions
-    'arrow-parens': [ 2, 'as-needed' ],
+    'arrow-parens': [ 'error', 'as-needed' ],
 
-    'no-trailing-spaces': [ 2, { skipBlankLines: true, ignoreComments: true } ],
+    'no-trailing-spaces': [ 'error', { skipBlankLines: true, ignoreComments: true } ],
 
     // enforce spacing inside array brackets
     'array-bracket-spacing': [ 'error', 'always' ],
@@ -260,7 +245,7 @@ module.exports = {
     // disallow use of the Object constructor
     'no-new-object': 'error',
 
-    'no-template-curly-in-string': 2,
+    'no-template-curly-in-string': 'error',
 
     // disallow space between function identifier and application
     'no-spaced-func': 'error',

--- a/eslint/README.md
+++ b/eslint/README.md
@@ -1,48 +1,84 @@
+# ESLint with PhET
 
-## eslint configuration for PhET
+## Overview
 
-### Overview
-In general, PhET's eslint configuration can be found in `./.eslintrc.js`. This base configuration specifies the majority
-of the rules used in the project, including the custom rules that have been created for the project (see `./rules/`).
+PhET uses [ESLint](https://eslint.org/) to statically analyze our code, solving several tasks:
+
+- Find logical and syntax errors, eg misspelled variables.
+- Ensure code conforms to PhET's style guideline, eg files must start with a copyright notice.
+- Ensure code is formatted correctly, eg indentation is two spaces.
+- Something else?
+- Autofix as many of these issues as possible.
+
+We use these tools at several stages of development:
+
+- Automatically highlighting errors and formatting code in our IDEs as we code.
+- Checking code during pre-commit hooks.
+- In continuous integration tests in [aqua](https://github.com/phetsims/aqua).
+- Elsewhere as well?
+
+## Usage
+
+For developers looking to ensure their changes pass ESLint, the typical entry point
+is to run `grunt lint`. See `grunt lint --help` for options. If your code passes
+`grunt lint`, then it is good to merge. You can add the `--format` option to
+[WHEN SHOULD I ACTUALLY USE FORMAT? AS AN EXTERNAL DEV]
+
+## Shared Configuration Files
+
+This directory (`chipper/eslint`) contains most of the
+[configuration for ESLint](https://eslint.org/docs/user-guide/configuring/).
+ESLint uses cascading configuration, similar to CSS, so we can provide an inheritance
+tree of configuration settings.
 
 Here is a list of all the available configuration files and why to use them for a repo:
 
-* `.eslintrc.js` is the main set of rules, and should be used for browser code that isn't used in sims, see `sim_eslint.js` for sim configuration (i.e. `phetmarks`).
-* `node_eslintrc.js` expands on the base rules and adds configuration only intended for Node.js code (i.e. `perennial`).
-* `sim_eslint.js` expands on the base rules and adds configuration intended for code run in sims (think of this as es5 sim rules)
-* `sim_es6_eslint.js` expands on the sim rules and adds configuration intended for sims that have no es5 in them (i.e. `wave-interference`)
-* `sim_es6_eslint_review.js` expands on `sim_es6_eslint.js` and adds rules that could be helpful during a code review
+- `.eslintrc.js` is the base set of rules. You probably shouldn't use this directly, instead you should use one
+  of the derived configurations below.
+- `node_eslintrc.js` expands on the base rules and adds configuration only intended for Node.js code (i.e. `perennial`).
+- `sim_eslintrc.js` expands on the base rules and adds configuration intended for code run in sims (think of this as es5 sim rules)
+- `sim_es6_eslintrc.js` expands on the sim rules and adds configuration for sims that have no es5 in them (i.e. `wave-interference`)
+- `format_eslintrc.js` contains additional rules used for enforcing code formatting. These are not required, they are just
+  recommended.
 
 So here is the hierarchy of chipper's config files. Indentation symbolized the "extends" relationship.
 
 ```
-.eslint.js
+format_eslintrc.js
+.eslintrc.js
   node_eslintrc.js
-  sim_eslint.js
-    sim_es6_eslint.js
+  sim_eslintrc.js
+    sim_es6_eslintrc.js
 ```
 
-The project is set up based on configuration files extending others using the "extends" key. By default, a configuration 
-file in a child dir will completely override a parent directory. Be sure appropriately extend, and don't blow away a 
-default configuration when you think you are just overriding. 
+PhET also uses some custom linting rules to detect PhET-specific errors, such as
+ensuring that each file contains a copyright notice. These custom rules live
+under the `./rules/` directory.
 
-A few definitions of terms:
-* The "base config" file is `chipper/eslint/.eslintrc.js`. All config files should at some point in the chain extend back 
-to it. It defines the core rules for the project.
-* The "default config" file for a repo is the file that it extends that applies to the whole repository, must be a 
-configuration file located in `chipper/eslint/`.
+## Configuring a repo
 
-### Usage
+Each PhET repo specifies which of the above configurations to use. This is
+usually specified in the `eslintConfig` section of the repo's `package.json`.
+Usually you should use the `extends` keyword to build upon one of the
+above configurations. Linting rules specific to the repo can be declared
+or modified here. For example see `scenery/package.json`.
 
-In each repo's `package.json`, the key `eslintConfig` specifies the eslint config for the repo, and should extend one of 
-the default config files here in `./chipper/eslint`, (described above). Additional rules specific to the directory (like 
-whitelisted globals) can be specified here to. For example see `studio/package.json`.
+If there is a sub-directory that requires specific configuration (or the repo
+doesn't have a `package.json`, like `sherpa`), you can
+create a file called `.eslintrc.js` in that directory, and specify the
+necessary configuration there. For example see `chipper/test/eslintrc.js`.
 
-If there is a sub directory that requires specific configuration, you should create a file called `.eslintrc.js` in that
-directory, and specify the necessary configuration there. Don't forget that you also need to "extend" the default 
-configuration too. For example see `chipper/test/eslintrc.js`.
+Before creating a special configuration unique to one repo or sub-directory,
+answer these questions:
 
-NOTE: before creating a specific configuration file, answer these questions:
-  * Why does this rule apply here but not everywhere?
-  * May it apply in other places soon, and thus I should just add it to a configuration in `chipper/eslint/`?
-  * Though it only applies here, is it easier to maintain if we just add it to a default configuration file.
+- Why does this rule apply here but not everywhere?
+- May it apply in other places soon, and thus I should just add it to a configuration in `chipper/eslint/`?
+- Though it only applies here, is it easier to maintain if we just add it to a default configuration file?
+
+## See Also
+
+- For a discussion of how PhET decided to use ESLint for formatting, see
+  https://github.com/phetsims/phet-info/issues/150
+
+- While ESLint can be plugged into many IDEs to perform code formatting automatically, many
+  PhET developers use other plugins in their IDEs. See https://github.com/phetsims/phet-info/tree/master/ide

--- a/eslint/format_eslintrc.js
+++ b/eslint/format_eslintrc.js
@@ -3,11 +3,7 @@
 'use strict';
 
 /**
- * The base eslint configuration for the project
- * values for rules:
- * 0 - no error
- * 1 - warn
- * 2 - error
+ * Additional rules for formatting js. See ./README.md for more info.
  *
  * @author Sam Reid (PhET Interactive Simulations)
  * @author Michael Kauzmann (PhET Interactive Simulations)

--- a/eslint/node_eslintrc.js
+++ b/eslint/node_eslintrc.js
@@ -9,7 +9,7 @@
 module.exports = {
   extends: './.eslintrc.js',
   rules: {
-    'no-var': 2
+    'no-var': 'error'
   },
   env: {
 

--- a/eslint/sim_es6_eslintrc.js
+++ b/eslint/sim_es6_eslintrc.js
@@ -9,7 +9,7 @@
 module.exports = {
   extends: './sim_eslintrc.js',
   rules: {
-    'no-var': 2,
-    'no-template-curly-in-string': 2
+    'no-var': 'error',
+    'no-template-curly-in-string': 'error'
   }
 };

--- a/eslint/sim_eslintrc.js
+++ b/eslint/sim_eslintrc.js
@@ -4,11 +4,11 @@
 'use strict';
 
 /**
- * Eslint config applied only to sims that are completely written in es6, with no es5 code.
+ * Eslint config applied only to sims.
  */
 module.exports = {
   extends: './.eslintrc.js',
   rules: {
-    'bad-sim-text': 2
+    'bad-sim-text': 'error'
   }
 };

--- a/js/grunt/Gruntfile.js
+++ b/js/grunt/Gruntfile.js
@@ -260,12 +260,14 @@ module.exports = function( grunt ) {
   grunt.registerTask( 'build-for-server', 'meant for use by build-server only',
     [ 'build' ]
   );
-  grunt.registerTask( 'lint', 'lint js files that are specific to this repository.  Options:' +
-                              '' +
-                              '--disable-eslint-cache: cache will not be read or written' +
-                              '--fix: autofixable changes will be written to disk' +
-                              '--patterns: comma-separated list of directory/file patterns.  ' +
-                              'If not supplied, it will default to the repo where the command was run from.', wrapTask( async () => {
+  
+  grunt.registerTask( 'lint',
+    `lint js files. Options:
+--disable-eslint-cache: cache will not be read or written
+--fix: autofixable changes will be written to disk
+--format: Append an additional set of rules for formatting
+--patterns: comma-separated list of directory/file patterns. Default: repo where the command was run.`,
+    wrapTask( async () => {
 
     // --disable-eslint-cache disables the cache, useful for developing rules
     const cache = !grunt.option( 'disable-eslint-cache' );

--- a/js/grunt/lint.js
+++ b/js/grunt/lint.js
@@ -91,17 +91,14 @@ const lint = async ( patterns, options ) => {
     await ESLint.outputFixes( results );
   }
 
-  // 4. Format the results.
-  const formatter = await eslint.loadFormatter( 'stylish' );
-  const resultText = formatter.format( results );
-
+  // 4. Parse the results.
   const totalWarnings = _.sum( results.map( result => result.warningCount ) );
   const totalErrors = _.sum( results.map( result => result.errorCount ) );
 
-  const total = totalWarnings + totalErrors;
-
-  // 5. Output it.
-  if ( total > 0 ) {
+  // 5. Output results on errors.
+  if ( totalWarnings + totalErrors > 0 ) {
+    const formatter = await eslint.loadFormatter( 'stylish' );
+    const resultText = formatter.format( results );
     console.log( resultText );
     options.warn && grunt.fail.warn( `${totalErrors} errors and ${totalWarnings} warnings` );
   }

--- a/js/grunt/lint.js
+++ b/js/grunt/lint.js
@@ -41,7 +41,7 @@ const lint = async ( patterns, options ) => {
 
   options = _.assignIn( {
     cache: true,
-    format: false, // Use a separate set of rules purely for formatting code.
+    format: false, // append an extra set of rules for formatting code.
     fix: false, // whether fixes should be written to disk
     warn: true // whether errors should reported with grunt.warn
   }, options );


### PR DESCRIPTION
Building off of https://github.com/phetsims/phet-info/issues/150. As I looked through the changes and tried to understand what to do, I came across a few tweaks that I think would help. Some of them are straightforward minor style tweaks, but others are changes to the documentation. I wanted to change the documentation so that it was more use-oriented: How should PhET and external devs use ESLint? What are the standards for if code is considered acceptable? I'm not sure I got the duty of format_eslintrc.js exactly right, could someone double check that? I didn't quite understand the conclusions I should have from reading the narrative of https://github.com/phetsims/phet-info/issues/150.